### PR TITLE
merge package template from arlac77/npm-package-template

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+node_modules
 build
 tests
 doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 8.8.1
+  - 8.9.1
 sudo: false
 branches:
   only:
@@ -16,13 +16,12 @@ before_install:
   - npm i -g npm@latest
 before_script:
   - npm prune
-  - npm install -g codecov
-  - npm install coveralls
+  - npm install -g --production coveralls codecov
 script:
   - npm run cover
 after_script:
   - codecov
-  - cat ./build/coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+  - cat ./build/coverage/lcov.info | coveralls
   - npm run docs
 after_success:
   - npm run semantic-release

--- a/doc/jsdoc.json
+++ b/doc/jsdoc.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    "node_modules/jsdoc-babel"
+  ],
+  "babel": {
+    "presets": [
+      "env"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,10 +10,14 @@
   "homepage": "https://github.com/arlac77/npm-navigator#readme",
   "scripts": {
     "start": "webpack --config webpack.config.js",
-    "cover": "nyc ava",
+    "cover": "nyc --temp-directory build/nyc ava",
     "test": "ava",
-    "posttest": "npm run prepare",
-    "semantic-release": "semantic-release"
+    "posttest": "npm run prepare && markdown-doctest",
+    "semantic-release": "semantic-release",
+    "precover": "rollup -c tests/rollup.config.js",
+    "pretest": "rollup -c tests/rollup.config.js",
+    "prepare": "rollup -c",
+    "docs": "jsdoc2md --configure doc/jsdoc.json -l off -t doc/README.hbs -f src/*.js >README.md"
   },
   "devDependencies": {
     "ava": "^0.23.0",
@@ -22,9 +26,15 @@
     "html-loader": "^0.5.1",
     "htmllint-loader": "^2.1.4",
     "nyc": "^11.3.0",
-    "semantic-release": "^9.1.1",
+    "semantic-release": "^10.0.1",
     "webpack": "^3.8.1",
-    "xo": "^0.19.0"
+    "xo": "^0.19.0",
+    "jsdoc-to-markdown": "^3.0.2",
+    "jsdoc-babel": "^0.3.0",
+    "markdown-doctest": "^0.9.1",
+    "rollup": "^0.52.0",
+    "rollup-plugin-babel": "^3.0.2",
+    "rollup-plugin-multi-entry": "^2.0.2"
   },
   "engines": {
     "node": ">=8.9.1"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,17 @@
+import babel from 'rollup-plugin-babel';
+import pkg from './package.json';
+
+export default {
+  input: pkg.module,
+  output: {
+    file: pkg.main,
+    format: 'cjs'
+  },
+  plugins: [
+    babel({
+      babelrc: false,
+      presets: ['env'],
+      exclude: 'node_modules/**'
+    })
+  ]
+};

--- a/tests/rollup.config.js
+++ b/tests/rollup.config.js
@@ -1,0 +1,20 @@
+import babel from 'rollup-plugin-babel';
+import multiEntry from 'rollup-plugin-multi-entry';
+
+export default {
+  input: 'tests/**/*-test.js',
+  output: {
+    file: 'build/bundle-test.js',
+    format: 'cjs',
+    sourcemap: true
+  },
+  external: ['ava'],
+  plugins: [
+    babel({
+      babelrc: false,
+      presets: ['env'],
+      exclude: 'node_modules/**'
+    }),
+    multiEntry()
+  ]
+};


### PR DESCRIPTION
package.json
---
- chore(scripts): update cover@nyc --temp-directory build/nyc ava from template
- chore(scripts): add precover@rollup -c tests/rollup.config.js from template
- chore(scripts): add pretest@rollup -c tests/rollup.config.js from template
- chore(scripts): update posttest@npm run prepare && markdown-doctest from template
- chore(scripts): add prepare@rollup -c from template
- chore(scripts): add docs@jsdoc2md --configure doc/jsdoc.json -l off -t doc/README.hbs -f src/*.js >README.md from template
- chore(devDependencies): add jsdoc-to-markdown@^3.0.2 from template
- chore(devDependencies): add jsdoc-babel@^0.3.0 from template
- chore(devDependencies): add markdown-doctest@^0.9.1 from template
- chore(devDependencies): add rollup@^0.52.0 from template
- chore(devDependencies): add rollup-plugin-babel@^3.0.2 from template
- chore(devDependencies): add rollup-plugin-multi-entry@^2.0.2 from template
- chore(devDependencies): update semantic-release@^10.0.1 from template
- docs(package): remove keyword null

.travis.yml
---
- chore(travis): merge from template .travis.yml

doc/jsdoc.json
---
- chore: update from template

rollup.config.js
---
- chore(rollup): copy from template

tests/rollup.config.js
---
- chore(rollup): copy from template

.npmignore
---
- chore(npm): update .npmignore from template
